### PR TITLE
修复PicGo配置“path”为空时导致的报错问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,9 @@ const parseOptions = (
 const parseUrl = (config: GiteaConfig, fileName: string) => {
   const { url, owner, repo, path } = config;
 
-  let new_path = path.replace(/{(.*?)}/gi, (match) => {
+  let new_path = path?.replace(/{(.*?)}/gi, (match) => {
     return dayjs().format(match.replace(/{|}/g, ""));
-  });
+  }) || "/";
 
   const myUrl = new nodeUrl.URL(url);
   myUrl.pathname = nodePath.join(


### PR DESCRIPTION
PicGo的图床设置中“path”可以为空，为空的时候会因为调用path的replace函数导致index.ts:37报错，这里针对这个情况作了修复；